### PR TITLE
Updating docker-compose.yml for mongo-experess to connect to DB

### DIFF
--- a/mongo_mongo_express/docker-compose.yml
+++ b/mongo_mongo_express/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
       ME_CONFIG_MONGODB_ADMINPASSWORD: example
+      ME_CONFIG_MONGODB_SERVER: mongo-db
     container_name:   mongo-express
 
     networks:


### PR DESCRIPTION
For mongo-express to connect to the database we need to add the option ME_CONFIG_MONGODB_SERVER: mongo-db so it can find the container over the localnet